### PR TITLE
Fix:cannot draw if text is spannedellipsizer

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,7 +39,7 @@ afterEvaluate {
                 artifact tasks.androidSourcesJar
                 groupId = 'jp.tomorrowkey.android.gifplayer'
                 artifactId = 'gifplayer'
-                version = '1.3.0'
+                version = '1.3.1-SNAPSHOT'
             }
         }
     }

--- a/library/src/main/java/jp/tomorrowkey/android/gifplayer/GifSpan.java
+++ b/library/src/main/java/jp/tomorrowkey/android/gifplayer/GifSpan.java
@@ -108,7 +108,6 @@ public class GifSpan extends ReplacementSpan {
 		if (text instanceof Spanned) {
 			Spanned spanned = (Spanned) text;
 			if (spanned.getSpanStart(this) == -1) {
-				Timber.tag(TAG).d("return");
 				return;
 			}
 		}

--- a/library/src/main/java/jp/tomorrowkey/android/gifplayer/GifSpan.java
+++ b/library/src/main/java/jp/tomorrowkey/android/gifplayer/GifSpan.java
@@ -8,6 +8,7 @@ import android.graphics.Paint;
 import android.graphics.Paint.FontMetricsInt;
 import android.os.AsyncTask;
 import android.text.Editable;
+import android.text.Spanned;
 import android.text.style.ReplacementSpan;
 import android.util.TypedValue;
 import android.view.View;
@@ -72,10 +73,11 @@ public class GifSpan extends ReplacementSpan {
 		if (view == null) {
 			return 0;
 		}
-		if (text != view.getText()) {
-			// Don't use equals because SpannableStringBuilder#equals was broken
-			// https://android.googlesource.com/platform/frameworks/base/+/6b4380ea5f71f031d1105d8986c813fefe056794
-			return 0;
+		if (text instanceof Spanned) {
+			Spanned spanned = (Spanned) text;
+			if (spanned.getSpanStart(this) == -1) {
+				return 0;
+			}
 		}
 
 		if (scaleToTextSize > 0) {
@@ -103,10 +105,12 @@ public class GifSpan extends ReplacementSpan {
 		if (view == null) {
 			return;
 		}
-		if (text != view.getText()) {
-			// Don't use equals because SpannableStringBuilder#equals was broken
-			// https://android.googlesource.com/platform/frameworks/base/+/6b4380ea5f71f031d1105d8986c813fefe056794
-			return;
+		if (text instanceof Spanned) {
+			Spanned spanned = (Spanned) text;
+			if (spanned.getSpanStart(this) == -1) {
+				Timber.tag(TAG).d("return");
+				return;
+			}
 		}
 
 		if (decodeStatus == DECODE_STATUS_UNDECODE) {


### PR DESCRIPTION
Fix cannot draw if text is SpannedEllipsizer in GifSpan#draw.
If text is android.text.Layout.SpannedEllipsizer, `text ! = view.getText()` will be false and not drawn.